### PR TITLE
Support empty (`serde_json::to_value(())`) responses

### DIFF
--- a/lambda-debug-proxy-client/Cargo.toml
+++ b/lambda-debug-proxy-client/Cargo.toml
@@ -19,6 +19,6 @@ bs58 = "0.4"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 log = "0.4"
-lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime.git" }
+lambda_runtime = "0.5.1"
 rusoto_sqs = { version = "0.47", features = ["rustls"], default-features = false }
 rusoto_core = { version = "0.47", features = ["rustls"], default-features = false }

--- a/lambda-debug-proxy/Cargo.toml
+++ b/lambda-debug-proxy/Cargo.toml
@@ -20,6 +20,6 @@ bs58 = "0.4"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.3"
 log = "0.4"
-lambda_runtime = { git = "https://github.com/awslabs/aws-lambda-rust-runtime.git" }
+lambda_runtime = "0.5.1"
 rusoto_sqs = { version = "0.47", features = ["rustls"], default-features = false }
 rusoto_core = { version = "0.47", features = ["rustls"], default-features = false }

--- a/lambda-debug-proxy/src/main.rs
+++ b/lambda-debug-proxy/src/main.rs
@@ -118,7 +118,7 @@ async fn my_handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
 /// or returns as-is if it's not encoded/compressed.
 fn decode_maybe_binary(body: String) -> String {
     // check for presence of { at the beginning of the doc to determine if it's JSON or Base58
-    if body.len() == 0 || body.trim_start().starts_with("{") {
+    if body.len() == 0 || body.trim_start().starts_with("{") || body.trim() == "null" {
         // looks like JSON - return as-is
         return body;
     }


### PR DESCRIPTION
Hi! This is an awesome project.

I just got it going with some Lambdas I'm working on, and it's working perfectly.
I ran into two small issues while getting it going:
- If my project and and the debug proxy are building against two separate versions of `lambda_runtime`, it fails because it can't determine which crate to use types from
- Sending responses from Lambdas that use `Ok(())` to denote success fails because it thinks that JSON `null` is base58-encoded
    - Lambdas that return `Ok(())` include ones that handle batches of events (like a DynamoDB streams processing Lambda)

To fix this, I:
- pinned the `lambda_runtime` version to `"0.5.1"` (latest release)
- modified the base58 check to check for `null` bodies